### PR TITLE
fix: guard zero native price in oracle and bridge, order wormhole send checks

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -304,7 +304,9 @@ contract Bridge is GasUsage, Router, MessengerGateway, IBridge {
         IERC20 token = IERC20(tokenAddress_);
         token.safeTransferFrom(user, address(this), feeTokenAmount);
 
-        uint fee = (bridgingFeeConversionScalingFactor[tokenAddress_] * feeTokenAmount) / gasOracle.price(chainId);
+        uint nativePrice = gasOracle.price(chainId);
+        require(nativePrice > 0, "Bridge: unset native token price");
+        uint fee = (bridgingFeeConversionScalingFactor[tokenAddress_] * feeTokenAmount) / nativePrice;
 
         emit BridgingFeeFromTokens(fee);
         return fee;

--- a/contracts/GasOracle.sol
+++ b/contracts/GasOracle.sol
@@ -70,9 +70,11 @@ contract GasOracle is Ownable, IGasOracle {
         uint otherChainId,
         uint gasAmount
     ) external view override returns (uint) {
+        uint nativePrice = chainData[chainId].price;
+        require(nativePrice > 0, "GasOracle: unset native token price");
         return
             (chainData[otherChainId].gasPrice * gasAmount * chainData[otherChainId].price) /
-            chainData[chainId].price /
+            nativePrice /
             fromOracleToChainScalingFactor;
     }
 
@@ -91,7 +93,9 @@ contract GasOracle is Ownable, IGasOracle {
      * @param otherChainId The ID of the other chain to get the cross-rate for.
      */
     function crossRate(uint otherChainId) external view override returns (uint) {
-        return (chainData[otherChainId].price * ORACLE_SCALING_FACTOR) / chainData[chainId].price;
+        uint nativePrice = chainData[chainId].price;
+        require(nativePrice > 0, "GasOracle: unset native token price");
+        return (chainData[otherChainId].price * ORACLE_SCALING_FACTOR) / nativePrice;
     }
 
     /**

--- a/contracts/WormholeMessenger.sol
+++ b/contracts/WormholeMessenger.sol
@@ -44,6 +44,8 @@ contract WormholeMessenger is Ownable, GasUsage {
         require(otherChainIds[uint8(message[1])] != 0, "Messenger: wrong destination");
         bytes32 messageWithSender = message.hashWithSenderAddress(msg.sender);
 
+        require(sentMessages[messageWithSender] == 0, "WormholeMessenger: has message");
+
         uint32 nonce_ = nonce;
 
         uint256 wormholeFee = wormhole.messageFee();
@@ -57,7 +59,6 @@ contract WormholeMessenger is Ownable, GasUsage {
             nonce = nonce_ + 1;
         }
 
-        require(sentMessages[messageWithSender] == 0, "WormholeMessenger: has message");
         sentMessages[messageWithSender] = 1;
 
         emit MessageSent(messageWithSender, sequence);

--- a/test/gas-oracle.test.ts
+++ b/test/gas-oracle.test.ts
@@ -104,6 +104,13 @@ describe('GasOracle', () => {
         const rate3 = await gasOracle.crossRate(CHAIN_3);
         expect(rate3).eq(parseUnits('0.5', ORACLE_PRECISION));
       });
+
+      it('Failure: should revert when this chain native price is unset', async () => {
+        await gasOracle.setPrice(CHAIN_2, parseUnits('200', ORACLE_PRECISION));
+        await expect(gasOracle.crossRate(CHAIN_2)).revertedWith(
+          'GasOracle: unset native token price',
+        );
+      });
     });
 
     describe('price', () => {
@@ -150,6 +157,17 @@ describe('GasOracle', () => {
             CHAIN_PRECISION,
           ),
         );
+      });
+
+      it('Failure: should revert when this chain native price is unset', async () => {
+        await gasOracle.setChainData(
+          CHAIN_2,
+          parseUnits('0.1', ORACLE_PRECISION),
+          parseUnits(formatUnits(420, 6), ORACLE_PRECISION),
+        );
+        await expect(
+          gasOracle.getTransactionGasCostInNativeToken(CHAIN_2, 50000),
+        ).revertedWith('GasOracle: unset native token price');
       });
     });
 


### PR DESCRIPTION
This PR addresses two issues:

**Gas oracle / Bridge:** When the native token USD price is unset (zero), code that divides by this price could hit division-by-zero. The changes add guards so we do not perform those calculations with a zero denominator.

**WormholeMessenger:** The duplicate-message check is ordered before the external call (aligned with the Messenger pattern), so we fail fast on duplicates without invoking the bridge contract unnecessarily.

**Tests:** gas-oracle.test.ts is updated to cover the new behavior.

contribution: made by mooncitydev